### PR TITLE
docs: fix simple typo, recieve -> receive

### DIFF
--- a/examples/python_ex.py
+++ b/examples/python_ex.py
@@ -4,7 +4,7 @@ McFlyin API example.
 
 Take data from Python to send to an API in Python to transform data in Python to receive in Python to transform in Python.
 
-But you can take data from ___ to send to an API in Python to transform data in Python to recieve in ____ to transform in ____
+But you can take data from ___ to send to an API in Python to transform data in Python to receive in ____ to transform in ____
 
 '''
 


### PR DESCRIPTION
There is a small typo in examples/python_ex.py.

Should read `receive` rather than `recieve`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md